### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/job.js
+++ b/job.js
@@ -3,7 +3,7 @@
 var assert = require('assert');
 
 //contrib
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var async = require('async');
 var amqp = require('amqp');
 

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "url": "https://github.com/soichih/sca-datamover/issues"
   },
   "dependencies": {
-    "node-uuid": "~1.4.3",
-    "async": "~1.4.2",
-    "winston": "~1.0.1",
     "amqp": "~0.2.4",
-    "concat-stream": "~1.5.0"
+    "async": "~1.4.2",
+    "concat-stream": "~1.5.0",
+    "uuid": "^3.0.0",
+    "winston": "~1.0.1"
   },
   "devDependencies": {
     "mocha": "~2.3.3",

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var assert = require('assert');
 //var request = require('supertest');  
 //var amqp = require('amqp');
-//var uuid = require('node-uuid');
+//var uuid = require('uuid');
 //var winston = require('winston');
 
 //mine


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.